### PR TITLE
BREAKING CHANGE: rename map -> switchMap

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -38,12 +38,6 @@ which accepts a value to resolve later.</p>
 are strings, a string is returned. Otherwise, a function is returned that
 accepts an object and returns a string by resolving any functions.</p>
 </dd>
-<dt><a href="#map">map(map, key)</a> ⇒ <code>Resolver</code> | <code>String</code></dt>
-<dd><p>The <code>map</code> function is for <em>mapping</em> keys to values.
-Given a <code>map</code> and a <code>key</code>, it will resolve to a value
-immediately (if possible), or return a function with may be passed an object
-to resolve later.</p>
-</dd>
 <dt><a href="#not">not(value)</a> ⇒ <code>Resolver</code> | <code>Boolean</code></dt>
 <dd><p>The <code>not</code> function is for resolving logical &quot;not&quot; of some
 <em>single condition</em>. Given <code>value</code>, <code>not</code> will
@@ -58,6 +52,12 @@ accepts a value to resolve later.</p>
 </dd>
 <dt><a href="#prop">prop(path)</a> ⇒ <code>Resolver</code></dt>
 <dd><p>Takes a path; returns a value-resolving function.</p>
+</dd>
+<dt><a href="#switchMap">switchMap(map, key)</a> ⇒ <code>Resolver</code> | <code>String</code></dt>
+<dd><p>The <code>switchMap</code> function is for <em>mapping</em> keys to values.
+Given a <code>map</code> and a <code>key</code>, it will resolve to a value
+immediately (if possible), or return a function with may be passed an object
+to resolve later.</p>
 </dd>
 <dt><a href="#tern">tern(a, b, test)</a> ⇒ <code>Resolver</code> | <code>String</code></dt>
 <dd><p>The <code>tern</code> function is for resolving some
@@ -156,22 +156,6 @@ accepts an object and returns a string by resolving any functions.
 | joiner | <code>String</code> | the string to join values with. |
 | ...values | <code>Resolver</code> \| <code>String</code> | The values to join together. |
 
-<a name="map"></a>
-
-## map(map, key) ⇒ <code>Resolver</code> \| <code>String</code>
-The <code>map</code> function is for <em>mapping</em> keys to values.
-Given a <code>map</code> and a <code>key</code>, it will resolve to a value
-immediately (if possible), or return a function with may be passed an object
-to resolve later.
-
-**Kind**: global function  
-**Returns**: <code>Resolver</code> \| <code>String</code> - A value or a resolver.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| map | <code>Object</code> | Maps values to values OR value-resolving funcs. |
-| key | <code>Resolver</code> \| <code>String</code> | Value or function that resolves to value. |
-
 <a name="not"></a>
 
 ## not(value) ⇒ <code>Resolver</code> \| <code>Boolean</code>
@@ -214,6 +198,22 @@ Takes a path; returns a value-resolving function.
 | Param | Type | Description |
 | --- | --- | --- |
 | path | <code>String</code> | A valid path in a props object. |
+
+<a name="switchMap"></a>
+
+## switchMap(map, key) ⇒ <code>Resolver</code> \| <code>String</code>
+The <code>switchMap</code> function is for <em>mapping</em> keys to values.
+Given a <code>map</code> and a <code>key</code>, it will resolve to a value
+immediately (if possible), or return a function with may be passed an object
+to resolve later.
+
+**Kind**: global function  
+**Returns**: <code>Resolver</code> \| <code>String</code> - A value or a resolver.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| map | <code>Object</code> | Maps values to values OR value-resolving funcs. |
+| key | <code>Resolver</code> \| <code>String</code> | Value or function that resolves to value. |
 
 <a name="tern"></a>
 

--- a/README.md
+++ b/README.md
@@ -119,12 +119,6 @@ which accepts a value to resolve later.</p>
 are strings, a string is returned. Otherwise, a function is returned that
 accepts an object and returns a string by resolving any functions.</p>
 </dd>
-<dt><a href="#map">map(map, key)</a> ⇒ <code>Resolver</code> | <code>String</code></dt>
-<dd><p>The <code>map</code> function is for <em>mapping</em> keys to values.
-Given a <code>map</code> and a <code>key</code>, it will resolve to a value
-immediately (if possible), or return a function with may be passed an object
-to resolve later.</p>
-</dd>
 <dt><a href="#not">not(value)</a> ⇒ <code>Resolver</code> | <code>Boolean</code></dt>
 <dd><p>The <code>not</code> function is for resolving logical &quot;not&quot; of some
 <em>single condition</em>. Given <code>value</code>, <code>not</code> will
@@ -139,6 +133,12 @@ accepts a value to resolve later.</p>
 </dd>
 <dt><a href="#prop">prop(path)</a> ⇒ <code>Resolver</code></dt>
 <dd><p>Takes a path; returns a value-resolving function.</p>
+</dd>
+<dt><a href="#switchMap">switchMap(map, key)</a> ⇒ <code>Resolver</code> | <code>String</code></dt>
+<dd><p>The <code>switchMap</code> function is for <em>mapping</em> keys to values.
+Given a <code>map</code> and a <code>key</code>, it will resolve to a value
+immediately (if possible), or return a function with may be passed an object
+to resolve later.</p>
 </dd>
 <dt><a href="#tern">tern(a, b, test)</a> ⇒ <code>Resolver</code> | <code>String</code></dt>
 <dd><p>The <code>tern</code> function is for resolving some
@@ -237,22 +237,6 @@ accepts an object and returns a string by resolving any functions.
 | joiner | <code>String</code> | the string to join values with. |
 | ...values | <code>Resolver</code> \| <code>String</code> | The values to join together. |
 
-<a name="map"></a>
-
-## map(map, key) ⇒ <code>Resolver</code> \| <code>String</code>
-The <code>map</code> function is for <em>mapping</em> keys to values.
-Given a <code>map</code> and a <code>key</code>, it will resolve to a value
-immediately (if possible), or return a function with may be passed an object
-to resolve later.
-
-**Kind**: global function  
-**Returns**: <code>Resolver</code> \| <code>String</code> - A value or a resolver.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| map | <code>Object</code> | Maps values to values OR value-resolving funcs. |
-| key | <code>Resolver</code> \| <code>String</code> | Value or function that resolves to value. |
-
 <a name="not"></a>
 
 ## not(value) ⇒ <code>Resolver</code> \| <code>Boolean</code>
@@ -295,6 +279,22 @@ Takes a path; returns a value-resolving function.
 | Param | Type | Description |
 | --- | --- | --- |
 | path | <code>String</code> | A valid path in a props object. |
+
+<a name="switchMap"></a>
+
+## switchMap(map, key) ⇒ <code>Resolver</code> \| <code>String</code>
+The <code>switchMap</code> function is for <em>mapping</em> keys to values.
+Given a <code>map</code> and a <code>key</code>, it will resolve to a value
+immediately (if possible), or return a function with may be passed an object
+to resolve later.
+
+**Kind**: global function  
+**Returns**: <code>Resolver</code> \| <code>String</code> - A value or a resolver.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| map | <code>Object</code> | Maps values to values OR value-resolving funcs. |
+| key | <code>Resolver</code> \| <code>String</code> | Value or function that resolves to value. |
 
 <a name="tern"></a>
 

--- a/src/__tests__/all.test.js
+++ b/src/__tests__/all.test.js
@@ -46,20 +46,28 @@ describe("resolvers", () => {
   describe("map", () => {
     it("returns a value if no resolvers exist", () => {
       const condition = { a: "A", b: "B" };
-      expect(resolvers.map(condition, "a")).toBe("A");
-      expect(resolvers.map(condition, "b")).toBe("B");
+      expect(resolvers.switchMap(condition, "a")).toBe("A");
+      expect(resolvers.switchMap(condition, "b")).toBe("B");
     });
     it("can also accept a value function to be resolved with props", () => {
       const props = { aa: "a", bb: "b" };
       const condition = { a: "A", b: "B" };
-      expect(resolvers.map(condition, resolvers.prop("aa"))(props)).toBe("A");
-      expect(resolvers.map(condition, resolvers.prop("bb"))(props)).toBe("B");
+      expect(resolvers.switchMap(condition, resolvers.prop("aa"))(props)).toBe(
+        "A"
+      );
+      expect(resolvers.switchMap(condition, resolvers.prop("bb"))(props)).toBe(
+        "B"
+      );
     });
     it("can also accept value functions in the condition object", () => {
       const props = { aa: "a", bb: "b", a: "A", b: "B" };
       const condition = { a: resolvers.prop("a"), b: resolvers.prop("b") };
-      expect(resolvers.map(condition, resolvers.prop("aa"))(props)).toBe("A");
-      expect(resolvers.map(condition, resolvers.prop("bb"))(props)).toBe("B");
+      expect(resolvers.switchMap(condition, resolvers.prop("aa"))(props)).toBe(
+        "A"
+      );
+      expect(resolvers.switchMap(condition, resolvers.prop("bb"))(props)).toBe(
+        "B"
+      );
     });
   });
   describe("tern", () => {

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -3,7 +3,7 @@ export { default as declare } from "./declare";
 export { default as includes } from "./includes";
 export { default as is } from "./is";
 export { default as join } from "./join";
-export { default as map } from "./map";
+export { default as switchMap } from "./switchMap";
 export { default as not } from "./not";
 export { default as or } from "./or";
 export { default as prop } from "./prop";

--- a/src/resolvers/switchMap.js
+++ b/src/resolvers/switchMap.js
@@ -1,7 +1,7 @@
 import { isResolver, resolve } from "../core";
 
 /**
- * The <code>map</code> function is for <em>mapping</em> keys to values.
+ * The <code>switchMap</code> function is for <em>mapping</em> keys to values.
  * Given a <code>map</code> and a <code>key</code>, it will resolve to a value
  * immediately (if possible), or return a function with may be passed an object
  * to resolve later.
@@ -10,7 +10,7 @@ import { isResolver, resolve } from "../core";
  * @param {Resolver|String} key Value or function that resolves to value.
  * @returns {Resolver|String} A value or a resolver.
  */
-const map = (map, key) =>
+const switchMap = (map, key) =>
   isResolver(key) ? o => resolve(map[key(o)], o) : map[key];
 
-export default map;
+export default switchMap;


### PR DESCRIPTION
We should reserve map for mapping an array of resolvers or something.